### PR TITLE
Support notifications via notify_rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,6 @@ path = "main.rs"
 
 [dependencies]
 notify-rust = "3.3"
+
+[target.'cfg(target_os = "macos")'.dependencies]
 mac-notification-sys = "0.1.0"


### PR DESCRIPTION
This adds support for GNU/Linux.

Fixes https://github.com/frewsxcv/alert-after/issues/1